### PR TITLE
Math lib improvements

### DIFF
--- a/examples/std-deviation.js
+++ b/examples/std-deviation.js
@@ -4,10 +4,10 @@ const { stdDeviation, filterStdDeviated, nBN } = require('../')
 
 const simple = [10500, 10700, 11500, '12300', 5000, 5100]
 let dev = stdDeviation(simple)
-let filtered = filterStdDeviated(simple, 1000)
+let filtered = filterStdDeviated(simple, 1)
 
 console.log(dev.toFixed()) // 2980.16591633568094682823
-console.log(filtered) // [ 10500, 10700, 11500, '12300' ]
+console.log(filtered) // [ 10500, 10700, 11500 ]
 
 const complex = [
   { x: nBN(10500), y: 'jan' },
@@ -19,6 +19,6 @@ const complex = [
 ]
 
 dev = stdDeviation(complex, a => a.x)
-filtered = filterStdDeviated(complex, 1000, a => a.x)
+filtered = filterStdDeviated(complex, 1, a => a.x)
 console.log(dev.toFixed()) // 2980.16591633568094682823
-console.log(filtered.map(a => a.x.toFixed())) // [ '10500', '10700', '11500', '12300' ]
+console.log(filtered.map(a => a.x.toFixed())) // [ '10500', '10700', '11500' ]

--- a/src/bn.js
+++ b/src/bn.js
@@ -17,6 +17,11 @@ const nBN = (value) => {
   if (value === 'Infinity' || value === '-Infinity' ||
     value === Infinity || value === -Infinity) throw new Error('ERR_NUM_INFINITE')
 
+  if ((value instanceof BigNumber) &&
+    (value.isNaN() || !value.isFinite())) {
+    throw new Error('ERR_NUM_NAN')
+  }
+
   try {
     return new BigNumber(value)
   } catch (err) {

--- a/src/vwap.js
+++ b/src/vwap.js
@@ -23,8 +23,8 @@ const VWAP = (values) => {
     y = y.plus(value.volume)
   }
 
-  if (y.toFixed(0) === '0') throw new Error('ERR_WEIGHT_SUM_ZERO')
-  return x.dividedBy(y).toFixed()
+  if (y.toString() === '0') throw new Error('ERR_WEIGHT_SUM_ZERO')
+  return x.dividedBy(y).toString()
 }
 
 /**
@@ -44,7 +44,7 @@ const EWVWAP = (values, weights) => {
     sum = sum.plus(value)
   })
 
-  if (sum.toFixed() !== '1') throw new Error('ERR_INVALID_WEIGHT_CONF')
+  if (sum.toString() !== '1') throw new Error('ERR_INVALID_WEIGHT_CONF')
 
   const prices = {}
   for (let i = 0; i < values.length; i++) {
@@ -66,8 +66,8 @@ const EWVWAP = (values, weights) => {
     y = y.plus(weights[key])
   })
 
-  if (y.toFixed(0) === '0') throw new Error('ERR_WEIGHT_SUM_ZERO')
-  return x.dividedBy(y).toFixed()
+  if (y.toString() === '0') throw new Error('ERR_WEIGHT_SUM_ZERO')
+  return x.dividedBy(y).toString()
 }
 
 module.exports = {

--- a/test/std-deviation.test.js
+++ b/test/std-deviation.test.js
@@ -2,7 +2,7 @@
 
 const { expect } = require('chai')
 const { BN } = require('../src/bn')
-const { stdDeviation, filterStdDeviated } = require('../src/std-deviation')
+const { stdDeviation, filterStdDeviated, zScore } = require('../src/std-deviation')
 const BigNumber = BN()
 
 module.exports = () => {
@@ -78,11 +78,27 @@ module.exports = () => {
       return expect(dev.toString()).to.be.equal('2980.16591633568094682823')
     })
 
+    it('zScore - it should calculate the expected value', () => {
+      return expect(zScore.bind(null, 33, null, 25)).to.throw()
+    })
+
+    it('zScore - it should return NaN on NaN values', () => {
+      return expect(zScore.bind(null, 190, NaN, 25)).to.throw()
+    })
+
+    it('zScore - it should return infinity on divide by zero', () => {
+      return expect(zScore.bind(null, 190, 150, 0)).to.throw()
+    })
+
+    it('zScore - it should calculate the expected value', () => {
+      return expect(zScore(190, 150, 25).toString()).to.be.equal('1.6')
+    })
+
     it('filterStdDeviated - it should fail with invalid input', () => {
       const values = ['10161', { price: '10261.235', amount: '1' }]
 
       return expect(
-        filterStdDeviated.bind(null, values, 2000)
+        filterStdDeviated.bind(null, values, 1)
       ).to.throw()
     })
 
@@ -90,7 +106,7 @@ module.exports = () => {
       const values = ['10152.235', 'a10261.235']
 
       return expect(
-        filterStdDeviated.bind(null, values, 2000)
+        filterStdDeviated.bind(null, values, 1)
       ).to.throw()
     })
 
@@ -105,15 +121,15 @@ module.exports = () => {
     it('filterStdDeviated - it should return expected value with valid config', () => {
       const values = [10500, 10700, 11500, '12300', 5000, 5100]
 
-      const res = filterStdDeviated(values, '2000')
-      const remaining = [10500, 10700, 11500, '12300']
+      const res = filterStdDeviated(values, '1')
+      const remaining = [10500, 10700, 11500]
       return expect(res).to.satisfy(res => res.every(n => remaining.includes(n)))
     })
 
     it('filterStdDeviated - it should work with single item in array', () => {
       const values = [10500]
 
-      const res = filterStdDeviated(values, 2000)
+      const res = filterStdDeviated(values, 1)
       expect(res.length).to.be.equal(1)
       return expect(res[0]).to.be.equal(10500)
     })
@@ -131,8 +147,8 @@ module.exports = () => {
       const values = [2, 3, '-4', 5]
 
       const res = filterStdDeviated(values, 1)
-      expect(res.length).to.be.equal(3)
-      const remaining = [2, 3, 5]
+      expect(res.length).to.be.equal(2)
+      const remaining = [2, 3]
       return expect(res).to.satisfy(res => res.every(n => remaining.includes(n)))
     })
 
@@ -146,8 +162,8 @@ module.exports = () => {
         { price: 5100, amount: '1' },
       ]
 
-      const res = filterStdDeviated(values, '2000', (a) => a.price)
-      const remaining = [10500, 10700, 11500, '12300']
+      const res = filterStdDeviated(values, '1', (a) => a.price)
+      const remaining = [10500, 10700, 11500]
       return expect(res).to.satisfy(res => res.every(a => remaining.includes(a.price)))
     })
 

--- a/test/std-deviation.test.js
+++ b/test/std-deviation.test.js
@@ -36,7 +36,7 @@ module.exports = () => {
 
       const dev = stdDeviation(values)
       expect(dev instanceof BigNumber).to.be.true
-      return expect(dev.toFixed()).to.be.equal('2980.16591633568094682823')
+      return expect(dev.toString()).to.be.equal('2980.16591633568094682823')
     })
 
     it('stdDeviation - it should work with single item in array', () => {
@@ -44,7 +44,7 @@ module.exports = () => {
 
       const dev = stdDeviation(values)
       expect(dev instanceof BigNumber).to.be.true
-      return expect(dev.toFixed()).to.be.equal('0')
+      return expect(dev.toString()).to.be.equal('0')
     })
 
     it('stdDeviation - it should return expected value with negative values', () => {
@@ -52,7 +52,7 @@ module.exports = () => {
 
       const dev = stdDeviation(values)
       expect(dev instanceof BigNumber).to.be.true
-      return expect(dev.toFixed()).to.be.equal('1.1180339887498948482')
+      return expect(dev.toString()).to.be.equal('1.1180339887498948482')
     })
 
     it('stdDeviation - it should return expected value with mixed positive/negative values', () => {
@@ -60,7 +60,7 @@ module.exports = () => {
 
       const dev = stdDeviation(values)
       expect(dev instanceof BigNumber).to.be.true
-      return expect(dev.toFixed()).to.be.equal('3.35410196624968454461')
+      return expect(dev.toString()).to.be.equal('3.35410196624968454461')
     })
 
     it('stdDeviation - it should return expected value with selector arg', () => {
@@ -75,7 +75,7 @@ module.exports = () => {
 
       const dev = stdDeviation(values, (a) => a.price)
       expect(dev instanceof BigNumber).to.be.true
-      return expect(dev.toFixed()).to.be.equal('2980.16591633568094682823')
+      return expect(dev.toString()).to.be.equal('2980.16591633568094682823')
     })
 
     it('filterStdDeviated - it should fail with invalid input', () => {


### PR DESCRIPTION
- Replaced `toFixed` with `toString`
- Fixed `y.toFixed(0)` part in division in vwap lib, this one caused divide by zero due to rounding 0.x to 0
- Added also `BigNumber` instance validations in `nBN`, if we provided a `NaN BigNumber` value `nBN` function didn't detect the issue
- Added `z-score` function
- Replaced primitive threshold comparison with `z-score` comparison, now it filters the values by comparing calculated z-scores with the threshold. Threshold has also default value 1.